### PR TITLE
如果用户掉线，http返回则会返回error

### DIFF
--- a/start_io.php
+++ b/start_io.php
@@ -74,8 +74,12 @@ $sender_io->on('workerStart', function(){
                 }else{
                     $sender_io->emit('new_msg', @$_POST['content']);
                 }
-                // http接口返回ok
-                return $http_connection->send('ok');
+                // http接口返回，如果客户断开socket返回fail
+                if(empty($uidConnectionMap[$to])){
+                    return $http_connection->send('error');
+                }else{
+                    return $http_connection->send('ok');
+                }
         }
         return $http_connection->send('fail');
     };


### PR DESCRIPTION
监听http端口，给客户发送消息，之前不管客户在不在线，http都会返回ok。这次如果用户掉线，会提示发送失败